### PR TITLE
fix(deploy): Restore .npmrc for Vercel build

### DIFF
--- a/nextjs/.npmrc
+++ b/nextjs/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

- Restores `.npmrc` with `legacy-peer-deps=true` required for `npm install` to succeed on Vercel
- Without this, the build fails due to peer dependency conflicts

## Test plan

- [x] Verified build succeeds on Vercel with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)