### PR TITLE
fix(deploy): Pin Node.js to 20.x for Vercel build

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0",
+    "node": "20.x",
     "npm": ">=10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Pins Node.js to `20.x` (LTS) to fix "unsupported digital envelope" error on Vercel
- Node.js 22+ requires `--openssl-legacy-provider` flag, pinning to 20.x avoids this

## Test plan

- [ ] Vercel build succeeds without OpenSSL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)