### PR TITLE
fix(deploy): Add vercel.json for Next.js subdirectory build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Ecommerce website like amazon",
   "main": "index.js",
   "scripts": {
-    "build": "cd nextjs && npm install --legacy-peer-deps && npm run build",
+    "build": "cd nextjs && npm run build",
     "start": "cd nextjs && npm start"
   },
   "repository": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "installCommand": "cd nextjs && npm install --legacy-peer-deps",
+  "buildCommand": "cd nextjs && npm run build",
+  "outputDirectory": "nextjs/.next"
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` at repo root to tell Vercel where the Next.js app lives
- Configures `installCommand`, `buildCommand`, and `outputDirectory` for the `nextjs/` subdirectory
- Fixes "No Output Directory named public found" error

## Test plan

- [ ] Vercel build succeeds on branch `tovercel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)