### PR TITLE
fix(deploy): Use rootDirectory in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,3 @@
 {
-  "framework": "nextjs",
-  "installCommand": "cd nextjs && npm install --legacy-peer-deps",
-  "buildCommand": "cd nextjs && npm run build",
-  "outputDirectory": "nextjs/.next"
+  "rootDirectory": "nextjs"
 }


### PR DESCRIPTION
## Summary

- Simplifies `vercel.json` to just `{ "rootDirectory": "nextjs" }`
- This tells Vercel to treat `nextjs/` as the project root, so it auto-detects Next.js, runs install and build correctly, and finds the output

## Test plan

- [ ] Vercel build succeeds on branch `tovercel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)