### PR TITLE
fix(deploy): Remove invalid vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "rootDirectory": "nextjs"
-}


### PR DESCRIPTION
## Summary

- Removes `vercel.json` — `rootDirectory` is not a valid schema property
- **IMPORTANT**: The client must set Root Directory in Vercel UI:
  - Go to **Settings > General > Root Directory**
  - Set it to `nextjs`
  - Redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)